### PR TITLE
Debug Hitbox Visualization

### DIFF
--- a/source/barrier.js
+++ b/source/barrier.js
@@ -15,7 +15,7 @@ export class Barrier {
 			boxSize: new p5.Vector(1.0, 1.0, 2.0),
 			// -> How large the collision box is (3d)
 			//  + z tells how many lanes the barrier will span (rounded up)
-			offset: new p5.Vector(-24, 48),
+			offset: new p5.Vector(-16, 60),
 			// -> Amount to offset the sprite (without effecting collisions)
 		},
 		lawnchair: {
@@ -40,22 +40,28 @@ export class Barrier {
 	
 	static preload() {
 		for (let variant_k of Object.keys(Barrier.VARIANTS)) {
-			const variant = Barrier.VARIANTS[variant_k];
+			let variant = Barrier.VARIANTS[variant_k];
 			
-			// TODO: will there be a need for fancier image types?
-			// yes! the green Jumper is a barrier, but a moving one.
+			// Oops, we're missing out on the key string.
+			// Here's a quick hack.
+			variant.name = variant_k;
+			
+			// if not already a p5 Image, convert it to one.
+			// this is the "loading" part of the preload.
 			if (typeof variant.image == "string")
 				variant.image = loadImage(variant.image);
+			
+			// nobody else should mutate this table.
+			Object.freeze(variant);
 		}
 	}
 	
 	constructor(variant = "brickwall", startPos) {
-		const VARIANT_V = Barrier.VARIANTS[variant];
+		if (typeof variant == "string")
+			variant = Barrier.VARIANTS[variant];
+		
 		this.variant = variant;
 		this.position = startPos || new p5.Vector();
-		this.image = VARIANT_V.image;
-		this.offset = VARIANT_V.offset || new p5.Vector();
-		this.imageSize = VARIANT_V.imageSize.copy();
 	}
 	 
 	// Move the barrier horizontally a specified amount.
@@ -68,9 +74,9 @@ export class Barrier {
 	draw() {
 		push();
 		translate(WORLD.toScreen(this.position));
-		translate(this.offset);
-		translate(-this.imageSize.x / 2, -this.imageSize.y);
-		image(this.image, 0, 0, this.imageSize.x, this.imageSize.y);
+		translate(this.variant.offset);
+		translate(-this.variant.imageSize.x / 2, -this.variant.imageSize.y);
+		image(this.variant.image, 0, 0, this.variant.imageSize.x, this.variant.imageSize.y);
 		pop();
 	}
 };

--- a/source/barrier.js
+++ b/source/barrier.js
@@ -8,32 +8,33 @@ import { WORLD } from "./world.js";
 export class Barrier {
 	static VARIANTS = {
 		brickwall: {
-			image: "assets/brickwall.png", // -> image path / image object
-			imageSize: new p5.Vector(123, 187), // -> how large the sprite is
-			boxSize: new p5.Vector(1.0, 1.0, 2.0), // How large the collision box is
-			offset: new p5.Vector(0, 48), // -> amount to offset the visuals (shouldn't affect the collisions)
-			//span: 2, // -> how many lanes this object spans (will use in the future?)
+			image: "assets/brickwall.png",
+			// -> image path / image object
+			imageSize: new p5.Vector(123, 187),
+			// -> how large the sprite should be drawn
+			boxSize: new p5.Vector(1.0, 1.0, 2.0),
+			// -> How large the collision box is (3d)
+			//  + z tells how many lanes the barrier will span (rounded up)
+			offset: new p5.Vector(-24, 48),
+			// -> Amount to offset the sprite (without effecting collisions)
 		},
 		lawnchair: {
 			image: "assets/lawnchair.png",
 			imageSize: new p5.Vector(100, 100),
 			boxSize: new p5.Vector(1.0, 1.0, 1.0),
 			offset: new p5.Vector(0, 16),
-			//span: 1,
 		},
 		jumpEnemy: {
 			image: "assets/jumper.gif",
 			imageSize: new p5.Vector(40, 40),
-			boxSize: new p5.Vector(1.0, 1.0, 1.0),
+			boxSize: new p5.Vector(0.5, 0.5, 0.8),
 			offset: new p5.Vector(0, 8),
-			//span: 1,
 		},
 		treeStump: {
 			image: "assets/treestump.png",
 			imageSize: new p5.Vector(50, 50),
-			boxSize: new p5.Vector(1.0, 1.0, 1.0),
+			boxSize: new p5.Vector(0.8, 0.8, 1.0),
 			offset: new p5.Vector(0, 16),
-			//span: 1,
 		},
 	};
 	

--- a/source/barrierManager.js
+++ b/source/barrierManager.js
@@ -1,31 +1,40 @@
 import { Barrier } from "./barrier.js";
 import { Timer } from "./timer.js";
+import { WORLD } from "./world.js";
 
 export class BarrierManager {
 	constructor() {
 		this.barriers = [];
+		this.spawnRate = new Timer(2);
 	}
 	
 	pushBarrier(variant, ofs = 0) {
+		let laneRange = 3 - Math.ceil(Barrier.VARIANTS[variant].boxSize.z);
+		let randomLane = Math.round(random(laneRange)) - laneRange / 2;
 		this.barriers.push(
-			new Barrier(variant, createVector(10 + ofs, 0, Math.round(random(-1, 1))))
+			new Barrier(variant, createVector(10 + ofs, 0, randomLane))
 		);
-		this.spawnRate = new Timer(2);
 	}
-
+	
+	// TODO: actually, should we accept a line between two points and
+	// check if that line is in the cube? i think i know the algorithm
+	// for that, then
 	checkAgainstBarriers(point) {
 		for (const BARRIER of this.barriers) {
-			const BARRIER_V = Barrier.VARIANTS[BARRIER.variant]
+			const BARRIER_V = Barrier.VARIANTS[BARRIER.variant];
 			let pointRB = point.copy().sub(BARRIER.position);
 			if (
-				pointRB.x > -BARRIER_V.boxSize.x / 2 && pointRB.x < BARRIER_V.boxSize.x / 2
-				&& pointRB.y >= 0 && pointRB.y < BARRIER_V.boxSize.y
-				&& pointRB.z > -BARRIER_V.boxSize.z / 2 && pointRB.z < BARRIER_V.boxSize.z / 2
+				pointRB.y >= 0
+				&& pointRB.y < +BARRIER_V.boxSize.y
+				&& pointRB.x > -BARRIER_V.boxSize.x / 2
+				&& pointRB.x < +BARRIER_V.boxSize.x / 2
+				&& pointRB.z > -BARRIER_V.boxSize.z / 2
+				&& pointRB.z < +BARRIER_V.boxSize.z / 2
 			) {
 				return BARRIER.variant;
 			}
 		}
-		return false;
+		return null; // -> didn't collide with any barrier
 	}
 	
 	// TODO: bgSpeed is strange here but whatever

--- a/source/sketch.js
+++ b/source/sketch.js
@@ -180,6 +180,9 @@ window.draw = function () {
 	// Barriers
 	barrierManager.draw();
 	
+	barrierManager.dbgDrawBoxes();
+	barrierManager.dbgDrawClosestLine();
+	
 	// == Heads-Up Display ==
 	
 	// Score Tracker

--- a/source/sketch.js
+++ b/source/sketch.js
@@ -163,6 +163,8 @@ window.draw = function () {
 	// Clear screen
 	background(0);
 	
+	// == World Objects ==
+	
 	// Wrapping background
 	image(gfxBackground, Math.round(backgroundX * WORLD.UNIT), 0, width, height);
 	image(gfxBackground, Math.round(backgroundX * WORLD.UNIT + width), 0, width, height);
@@ -177,6 +179,8 @@ window.draw = function () {
 	
 	// Barriers
 	barrierManager.draw();
+	
+	// == Heads-Up Display ==
 	
 	// Score Tracker
 	scoreTracker.draw();

--- a/source/world.js
+++ b/source/world.js
@@ -5,7 +5,7 @@ export const WORLD = {
 	
 	ORIGIN: new p5.Vector(225, 324),
 	
-	Z_COEF: new p5.Vector(1/8, -5/8),
+	Z_COEF: new p5.Vector(3/8, -5/8),
 	UNIT: 64,
 	
 	// `this` == WORLD inside functions defined in WORLD.
@@ -23,7 +23,7 @@ export const WORLD = {
 	// Takes a 2D vector, outputs... a "3D" vector.
 	// Only on XZ plane, sorry. Y component'll be 0.
 	toWorld: function(v) {
-		// TODO: this is not usable!!! fix pls!
+		throw new Error("TODO: not implemented");
 		return new p5.Vector(
 			v.x / +this.UNIT,
 			0,
@@ -35,6 +35,7 @@ export const WORLD = {
 	dbgDrawGrid() {
 		push();
 		
+		noFill();
 		stroke(0.125, 0.5, 0.25, 0.25);
 		strokeWeight(4);
 		
@@ -47,7 +48,7 @@ export const WORLD = {
 		}
 		
 		// horizontal lines
-		for (let z = -2; z <= 2; z++) {
+		for (let z = -1; z <= 1; z++) {
 			let fromLine = this.toScreen( new p5.Vector( -3, 0, z ) );
 			let toLine   = this.toScreen( new p5.Vector( +8, 0, z ) );
 			


### PR DESCRIPTION
Added a visualization of each hitbox's visuals, alongside some tweaks to both the barrier hitboxes and the world perspective to more closely match the barrier graphics.

![image of brick wall with a relatively good hitbox](https://user-images.githubusercontent.com/98928652/162815728-92e429e6-b7c7-421e-98c9-89ac53c684e4.png)

Also added a line drawn from the player to the front of the nearest hitbox.

![a line drawn from the basketball to the nearest barrier](https://user-images.githubusercontent.com/98928652/162815815-12b52c53-0d5a-4523-89ef-15ba76cae099.png)

Of course, these new hitboxes are not final either.

I think merging this will close #25 !!! Cool