### PR TITLE
Fix display issue in test runner

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -11,6 +11,7 @@
 			font-size: 14pt;
 			max-width: 64em;
 			margin: 1em auto;
+			padding: 0.5em;
 		}
 		ul.testResultList {
 			padding: 0;

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -109,10 +109,12 @@ export class TestRunner {
 		point.classList.add("testResult");
 		point.classList.add("testResultSuccess");
 		
+		let locationLink = "./" + test.location.replace(/:(\d+)/, "#$1");
+		
 		// Add the text.
 		point.innerHTML =
 			`Test <em>"${sanitizeBadly(test.name)}"</em> passed! ` +
-			`<weak>(${test.location})</weak>`;
+			`<weak>(<a href="${locationLink}">${test.location}</a>)</weak>`;
 		if (info !== "") point.innerHTML += `\n${sanitizeBadly(info)}`;
 		
 		// Add it to the end of the list!

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -25,6 +25,94 @@ function sanitizeBadly(thing) {
 		.replaceAll(">", "&gt;");
 }
 
+// Question: Why is the longest function in the test runner
+// a function that makes stack traces look nice?
+// Answer: Sorry!
+function formatStackTrace(errorObject) {
+	let stackTrace = errorObject.stack;
+	
+	if (stackTrace.includes('@')) {
+		// Firefox-style stack traces.
+		
+		// assert@http://localhost:8000/tests/util.js:2:20
+		// @http://localhost:8000/tests/testSounds.js:42:9
+		// runTest@http://localhost:8000/tests/runner.js:126:15
+		// runTests@http://localhost:8000/tests/runner.js:102:22
+		// @http://localhost:8000/tests/:73:17
+		
+		// Let's filter out garbage from stack traces.
+		return stackTrace.split('\n')
+		// Also note this is all one really long line.
+		// I just split it in a bizarre way to improve readability.
+		
+		// First we should really trim all these elements.
+		.map(i => i.trim())
+		
+		//⬇ @ signs at the start of locations
+		.map(i => i.startsWith('@') ? i.substring(1) : i)
+		
+		//⬇ Functions from either the test runner or its utility functions
+		.filter(i => !i.includes("tests/util.js"))
+		.filter(i => !i.includes("tests/runner.js"))
+		
+		//⬇ Long lists of folders at the start of locations
+		.map(i => i.substring(i.indexOf("/", i.indexOf("//") + 2)))
+		
+		//⬇ Inline/anonymous scripts
+		.filter(i => !i.includes(".html"))
+		.filter(i => !i.includes("/:"))
+		
+		//⬇ Empty strings
+		.filter(i => i.length > 0)
+		
+		// Finally join the lines back together, adding indentation too!
+		.join('\n\t');
+		
+		// Why aren't stack traces standardized?
+		// Maybe if they were, they wouldn't be strings.
+	} else if (stackTrace.includes(errorObject.message)) {
+		// Chrome-style stack traces.
+		
+		// Error: assertion failed
+		//     at assert (util.js:2:20)
+		//     at Object.body (testSounds.js:42:3)
+		//     at TestRunner.runTest (runner.js:126:15)
+		//     at TestRunner.runTests (runner.js:102:22)
+		//     at HTMLDocument.<anonymous> ((index):73:17)
+		
+		// (yes, indented with four spaces.)
+		// (yes, the error message is... there too.)
+		
+		// Remove redundant error message and associated information.
+		let actualStart = stackTrace.indexOf(errorObject.message) + errorObject.message.length + 1;
+		stackTrace = stackTrace.substring(actualStart);
+		
+		return stackTrace.split('\n')
+		// Also note this is all one really long line.
+		// I just split it in a bizarre way to improve readability.
+		
+		// First we should really trim all these elements.
+		.map(i => i.trim())
+		
+		//⬇ Functions from either the test runner or its utility functions
+		.filter(i => !i.includes("tests/util.js"))
+		.filter(i => !i.includes("tests/runner.js"))
+		
+		//⬇ Inline/anonymous scripts
+		.filter(i => !i.includes("<anonymous>"))
+		
+		//⬇ Long lists of folders at the start of locations
+		.map(i => i.substring(i.indexOf("/", i.indexOf("//") + 2)))
+		
+		//⬇ That darn closing parenthesis
+		.map(i => i.substring(0, i.length - 1))
+		
+		.join('\n\t')
+	}
+	
+	return stackTrace;
+}
+
 // The test runner!!!
 export class TestRunner {
 	constructor(elem) {
@@ -129,15 +217,8 @@ export class TestRunner {
 		point.classList.add("testResult");
 		point.classList.add("testResultFailure");
 		
-		let stackTrace = error.stack.trim()
-			.split('\n') // Do a bad hack to remove...
-			.map(i => i.startsWith('@') ? i.substring(1) : i) // useless @s
-			.filter(i => !i.includes("/util.js")) // utility functions
-			.filter(i => !i.includes("/runner.js")) // test runner fns
-			.map(i => i.substring(i.lastIndexOf('/') + 1))    // long paths
-			.filter(i => !i.includes(".html"))         // any inline script
-			.filter(i => !i.startsWith(":"))   // any inline script (again)
-			.join('\n\t'); // ...from stack trace. (Also indent!)
+		// Remove garbage from stack trace.
+		let stackTrace = formatStackTrace(error);
 		
 		// Add the text.
 		point.innerHTML =

--- a/tests/util.js
+++ b/tests/util.js
@@ -27,8 +27,13 @@ function probe(skip = 2, showFullPath = false) {
 		// not wanting to inspect where you yourself are!!
 		// ...But if you do, you can always set skip to 1.
 		
+		let splitStack = e.stack.split('\n');
+		
+		// Dirty hack. Increment skip if you're on Chrome.
+		if (splitStack[1].trimStart().startsWith("at ")) skip++;
+		
 		// Anyway, yeah -- we only need one entry from this whole thing.
-		location = e.stack.split('\n')[skip];
+		location = splitStack[skip];
 		
 		if (showFullPath) // just erase the @, since it'll be anonymous.
 			location = location.substring(location.indexOf('@') + 1);


### PR DESCRIPTION
![apologies for the generation loss on this image](https://user-images.githubusercontent.com/98928652/163925058-c657e77c-218f-4145-b47a-45b664a426a1.png)

When using Google Chrome, all test paths displayed as "util.js". This is due to Chrome-style stack traces including the Entire Gosh Dang Error Message at the top of the string. I've introduced several measures to fix this.

Alongside that, I've improved stack traces in some respects -- I now only remove the host name from the path, leaving behind which folder each error came from. This is good! Some errors come from the `source` folder, some come from `tests`. Plus, you have a link on successful tests that you can click to see the source code.